### PR TITLE
Scoring based consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ the marketplace offer list filtered by prime
 
 > Buys with highest probability the cheapest product, but also has a chance to buy more expensive products. The probabilities are calculated with a modified market power formula.
 
+* buy_scoring_based
+
+> Scores each offer based on price and quality. A lower score is better.
+The consumer buys from the best offer if its score is below or equal to the consumer's willingness to buy.
+The importance of price and quality and the willingness varies for each consumer (visit).
+
 #### Logistic regression behavior in detail
 
 The [logit behavior](https://github.com/hpi-epic/pricewars-consumer/blob/master/lib/buyingbehavior.rb#L94) implements a logistic regression with feature scaling and calculates for each offer the buying probability based on the feature coefficients provided in the behavior settings. Based on this buying probability for each offer, the consumer will actually choose an offer to buy.

--- a/app/controllers/behavior_controller.rb
+++ b/app/controllers/behavior_controller.rb
@@ -16,6 +16,7 @@ class BehaviorController < ApplicationController
     result.push(select_second_cheap_behavior)
     result.push(select_third_cheap_behavior)
     result.push(select_logit_coefficients)
+    result.push(select_scoring_based)
   end
 
   private
@@ -132,6 +133,16 @@ class BehaviorController < ApplicationController
     behavior['settings'] = {}
     behavior['settings_description'] = 'Behavior settings not necessary'
     behavior['amount'] = 100
+    behavior
+  end
+
+  def self.select_scoring_based
+    behavior = {}
+    behavior['name'] = 'scoring_based'
+    behavior['description'] = 'I consider price and quality with some factor in my buying decision. I won\'t buy the best offer if its score is above my willingness to buy.'
+    behavior['settings'] = {}
+    behavior['settings_description'] = 'Behavior settings not necessary'
+    behavior['amount'] = 0
     behavior
   end
 end

--- a/lib/buyingbehavior.rb
+++ b/lib/buyingbehavior.rb
@@ -104,6 +104,41 @@ class BuyingBehavior
     end
   end
 
+  def buy_scoring_based
+    # Compare with paper: "Dynamic Pricing under Competition on Online Marketplaces: A Data-Driven Approach"
+    # The scoring factors for price and quality are different for each consumer. A lower score is better.
+    # We generate a random factor within a specified value range.
+
+    price_factor_range = 1.0..1.0
+    quality_factor_range = 0.0..3.0
+    willingness_to_buy_range = 20.0..80.0
+
+    prng = Random.new
+    price_factor = prng.rand(price_factor_range)
+    quality_factor = prng.rand(quality_factor_range)
+    willingness_to_buy = prng.rand(willingness_to_buy_range)
+
+    def score(item, price_factor, quality_factor)
+      price_factor * item['price'] + quality_factor * item['quality']
+    end
+
+    scored_items = @items.map{|item| {item: item, score: score(item, price_factor, quality_factor)} }
+    best_scored_item = scored_items.min { |a, b| a[:score] <=> b[:score] }
+
+    if $debug
+      puts "Price factor #{price_factor}, Quality factor #{quality_factor}, Willingness score: #{willingness_to_buy}"
+      puts "Scored items:"
+      scored_items.sort { |a, b| a[:score] <=> b[:score] }.each {|element| puts "\t#{element}"}
+    end
+
+    # Only buy from the best offer if its score is lower or equal than the willingness to buy.
+    if best_scored_item[:score] <= willingness_to_buy
+      best_scored_item[:item]
+    else
+      nil
+    end
+  end
+
   private
 
   # Uses a modified market power formula to calculate buying probabilities.


### PR DESCRIPTION
This consumer scores available offers according to the following formular:
`score = price_factor * price + quality_factor * quality`
The consumer buys the best offer (lowest score) if its score is below or equal to the willingness to buy.

The factors are random for each consumer/visit and are:
```
price_factor = Uniform(1.0, 1.0) // price factor is currently always 1.0
quality_factor = Uniform(0.0, 3.0)
willingness_to_buy = Uniform(20.0, 80.0)
```

This behavior is not active in the default configuration (only prefer_cheap is active).

I wanted to write some tests for this behavior but couldn't run the consumer tests. Some command recommendations from the internet did not work and the readme does not help either.